### PR TITLE
install latest gcd

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,8 +7,8 @@ ENV DATASTORE_DATASET=$PROJ_ID
 ENV CONSISTENCY=0.9
 
 RUN mkdir -p ${DATADIR}
-RUN wget http://storage.googleapis.com/gcd/tools/gcd-v1beta2-rev1-3.0.0.zip
-RUN unzip gcd-v1beta2-rev1-3.0.0.zip && rm gcd-v1beta2-rev1-3.0.0.zip
-WORKDIR gcd-v1beta2-rev1-3.0.0
+RUN wget http://storage.googleapis.com/gcd/tools/gcd-v1beta2-rev1-3.0.2.zip
+RUN unzip gcd-v1beta2-rev1-3.0.2.zip && rm gcd-v1beta2-rev1-3.0.2.zip
+WORKDIR gcd-v1beta2-rev1-3.0.2
 
 CMD ./gcd.sh create -d $PROJ_ID /opt/gcd/data; ./gcd.sh start --consistency=$CONSISTENCY --host=0.0.0.0 --port=$PORT /opt/gcd/data


### PR DESCRIPTION
Install version 3.0.2 to resolve #2 

We've pushed this up to the docker hub as bigwednesdayio/gcd-local but will happily remove it if you can get your version updated.
